### PR TITLE
Fixes #21 Missing previews 21

### DIFF
--- a/src/Controller/BetterThumbsBackendController.php
+++ b/src/Controller/BetterThumbsBackendController.php
@@ -131,6 +131,13 @@ class BetterThumbsBackendController implements ControllerProviderInterface
 
                 // get the directory name recursively
                 // make the value the "basename" to display in our templates
+                // Original we made an image with glide doing
+                // $app['betterthumbs']->makeImage( $item['dirname'], ['w' => 200, 'h' => 133, 'fit' => 'crop' ] )
+                // This caused apache & lightspeed to choke in the backend and not display the cached image
+                // because an htaccess rule rewrites the cache route of /cache
+                // since we save to /files/.cache/ this caused issues since it was captured by the rewrite rule.
+                // Now just serve a file from disk and not worry about the cached image even though they may
+                // differ
                 $cachedImage += [
                     $item['dirname'] => [
                         'name' => $parts['basename'],

--- a/src/Controller/BetterThumbsBackendController.php
+++ b/src/Controller/BetterThumbsBackendController.php
@@ -132,7 +132,7 @@ class BetterThumbsBackendController implements ControllerProviderInterface
                 // get the directory name recursively
                 // make the value the "basename" to display in our templates
                 $cachedImage += [
-                    $app['betterthumbs']->makeImage( $item['dirname'], ['w' => 200, 'h' => 133, 'fit' => 'crop' ] ) => [
+                    $item['dirname'] => [
                         'name' => $parts['basename'],
                         'path' => $item['dirname']
                     ]


### PR DESCRIPTION
for the backend page of /betterthumbs/files and showing cached files serve the images from the regular files directory since apache / litespeed rewrite the cache route and prevent images from being displayed. 